### PR TITLE
Add PySpark pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # my first repo in github
+
+## PySpark Pipeline
+
+This repository now includes a simple PySpark transformation pipeline found in `pyspark_pipeline.py`. The script demonstrates creating a DataFrame, filtering rows, and aggregating the results.
+
+Run the pipeline with:
+
+```bash
+python pyspark_pipeline.py
+```
+

--- a/pyspark_pipeline.py
+++ b/pyspark_pipeline.py
@@ -1,0 +1,29 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, sum as _sum
+
+
+def run_pipeline():
+    """Run a simple PySpark transformation pipeline."""
+    spark = SparkSession.builder.appName("TransformationPipeline").master("local[*]").getOrCreate()
+
+    # Sample data for demonstration purposes
+    data = [
+        ("A", 1),
+        ("B", 2),
+        ("A", 3),
+    ]
+    df = spark.createDataFrame(data, ["category", "value"])
+
+    # Filter rows where value is greater than 1 and aggregate
+    result = (
+        df.filter(col("value") > 1)
+          .groupBy("category")
+          .agg(_sum("value").alias("total_value"))
+    )
+
+    result.show()
+    spark.stop()
+
+
+if __name__ == "__main__":
+    run_pipeline()


### PR DESCRIPTION
## Summary
- add a small PySpark pipeline example
- document how to run it

## Testing
- `python pyspark_pipeline.py` *(fails: Invalid Spark URL)*

------
https://chatgpt.com/codex/tasks/task_e_685b4b4f00548328bf3c3c3518888b73